### PR TITLE
Improve shadow statistics UI and fix calculation issues

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -475,12 +475,12 @@ async fn export_results(
 
                     // Create band descriptions for better identification
                     let mut band_descriptions = vec![
-                        "Total_Shadow_Hours_(solar_weighted)".to_string(),
-                        "Average_Shadow_Percentage_(of_solar_hours)".to_string(),
+                        "Total_Shadow_Hours".to_string(),
+                        "Average_Shadow_Fraction_(0-1)".to_string(),
                         "Max_Consecutive_Shadow_Hours".to_string(),
                         "Morning_Shadow_Hours_(before_solar_noon)".to_string(),
                         "Afternoon_Shadow_Hours_(after_solar_noon)".to_string(),
-                        "Solar_Efficiency_Percentage".to_string(),
+                        "Solar_Efficiency_Fraction_(0-1)".to_string(),
                         "Average_Daily_Solar_Hours".to_string(),
                         "Total_Available_Solar_Hours".to_string(),
                     ];
@@ -596,11 +596,11 @@ async fn validate_results_file(file_path: String) -> Result<ResultsMetadata, Str
     // Expected summary layers (first 8 bands)
     let summary_layers = vec![
         "Total Shadow Hours".to_string(),
-        "Average Shadow Percentage".to_string(),
+        "Average Shadow Fraction".to_string(),
         "Max Consecutive Shadow Hours".to_string(),
         "Morning Shadow Hours".to_string(),
         "Afternoon Shadow Hours".to_string(),
-        "Solar Efficiency Percentage".to_string(),
+        "Solar Efficiency Fraction".to_string(),
         "Average Daily Solar Hours".to_string(),
         "Total Available Solar Hours".to_string(),
     ];

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -253,6 +253,8 @@ struct AllSummaryData {
     morning_shadow_hours: Vec<Vec<f32>>,
     noon_shadow_hours: Vec<Vec<f32>>,
     afternoon_shadow_hours: Vec<Vec<f32>>,
+    daily_solar_hours: Vec<Vec<f32>>,
+    total_available_solar_hours: Vec<Vec<f32>>,
     bounds: RasterBounds,
     transform: Vec<f64>,
 }
@@ -349,6 +351,22 @@ async fn get_all_summary_data(state: State<'_, AppState>) -> Result<AllSummaryDa
                 .map(|row| row.to_vec())
                 .collect();
 
+            let daily_solar_hours: Vec<Vec<f32>> = results
+                .summary_stats
+                .daily_solar_hours
+                .slice(ndarray::s![0, .., ..])
+                .outer_iter()
+                .map(|row| row.to_vec())
+                .collect();
+
+            let total_available_solar_hours: Vec<Vec<f32>> = results
+                .summary_stats
+                .total_available_solar_hours
+                .slice(ndarray::s![0, .., ..])
+                .outer_iter()
+                .map(|row| row.to_vec())
+                .collect();
+
             Ok(AllSummaryData {
                 total_shadow_hours,
                 avg_shadow_percentage,
@@ -356,6 +374,8 @@ async fn get_all_summary_data(state: State<'_, AppState>) -> Result<AllSummaryDa
                 morning_shadow_hours,
                 noon_shadow_hours,
                 afternoon_shadow_hours,
+                daily_solar_hours,
+                total_available_solar_hours,
                 bounds: clipped_info.bounds.clone(),
                 transform: clipped_info.transform.clone(),
             })

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -251,6 +251,7 @@ struct AllSummaryData {
     avg_shadow_percentage: Vec<Vec<f32>>,
     max_consecutive_shadow: Vec<Vec<f32>>,
     morning_shadow_hours: Vec<Vec<f32>>,
+    noon_shadow_hours: Vec<Vec<f32>>,
     afternoon_shadow_hours: Vec<Vec<f32>>,
     bounds: RasterBounds,
     transform: Vec<f64>,
@@ -332,6 +333,14 @@ async fn get_all_summary_data(state: State<'_, AppState>) -> Result<AllSummaryDa
                 .map(|row| row.to_vec())
                 .collect();
 
+            let noon_shadow_hours: Vec<Vec<f32>> = results
+                .summary_stats
+                .noon_shadow_hours
+                .slice(ndarray::s![0, .., ..])
+                .outer_iter()
+                .map(|row| row.to_vec())
+                .collect();
+
             let afternoon_shadow_hours: Vec<Vec<f32>> = results
                 .summary_stats
                 .afternoon_shadow_hours
@@ -345,6 +354,7 @@ async fn get_all_summary_data(state: State<'_, AppState>) -> Result<AllSummaryDa
                 avg_shadow_percentage,
                 max_consecutive_shadow,
                 morning_shadow_hours,
+                noon_shadow_hours,
                 afternoon_shadow_hours,
                 bounds: clipped_info.bounds.clone(),
                 transform: clipped_info.transform.clone(),
@@ -413,7 +423,7 @@ async fn export_results(
                         .map_err(|e| format!("Failed to clip: {}", e))?;
 
                     // Combine summary stats and time series
-                    let n_summary = 8;
+                    let n_summary = 9;
                     let (n_times, n_rows, n_cols) = results.shadow_fraction.dim();
                     let mut combined =
                         ndarray::Array3::<f32>::zeros((n_summary + n_times, n_rows, n_cols));
@@ -446,22 +456,28 @@ async fn export_results(
                     combined.slice_mut(ndarray::s![4, .., ..]).assign(
                         &results
                             .summary_stats
-                            .afternoon_shadow_hours
+                            .noon_shadow_hours
                             .slice(ndarray::s![0, .., ..]),
                     );
                     combined.slice_mut(ndarray::s![5, .., ..]).assign(
                         &results
                             .summary_stats
-                            .solar_efficiency_percentage
+                            .afternoon_shadow_hours
                             .slice(ndarray::s![0, .., ..]),
                     );
                     combined.slice_mut(ndarray::s![6, .., ..]).assign(
                         &results
                             .summary_stats
-                            .daily_solar_hours
+                            .solar_efficiency_percentage
                             .slice(ndarray::s![0, .., ..]),
                     );
                     combined.slice_mut(ndarray::s![7, .., ..]).assign(
+                        &results
+                            .summary_stats
+                            .daily_solar_hours
+                            .slice(ndarray::s![0, .., ..]),
+                    );
+                    combined.slice_mut(ndarray::s![8, .., ..]).assign(
                         &results
                             .summary_stats
                             .total_available_solar_hours
@@ -478,8 +494,9 @@ async fn export_results(
                         "Total_Shadow_Hours".to_string(),
                         "Average_Shadow_Fraction_(0-1)".to_string(),
                         "Max_Consecutive_Shadow_Hours".to_string(),
-                        "Morning_Shadow_Hours_(before_solar_noon)".to_string(),
-                        "Afternoon_Shadow_Hours_(after_solar_noon)".to_string(),
+                        "Morning_Shadow_Hours_(before_solar_noon_minus_2h)".to_string(),
+                        "Noon_Shadow_Hours_(solar_noon_±2h)".to_string(),
+                        "Afternoon_Shadow_Hours_(after_solar_noon_plus_2h)".to_string(),
                         "Solar_Efficiency_Fraction_(0-1)".to_string(),
                         "Average_Daily_Solar_Hours".to_string(),
                         "Total_Available_Solar_Hours".to_string(),
@@ -585,20 +602,21 @@ async fn validate_results_file(file_path: String) -> Result<ResultsMetadata, Str
     let shape = raster_data.data.shape();
     let (n_bands, n_rows, n_cols) = (shape[0], shape[1], shape[2]);
 
-    // Validate that we have at least 8 summary bands
-    if n_bands < 8 {
+    // Validate that we have at least 9 summary bands
+    if n_bands < 9 {
         return Err(format!(
-            "Results file must have at least 8 bands (summary layers), found {}",
+            "Results file must have at least 9 bands (summary layers), found {}",
             n_bands
         ));
     }
 
-    // Expected summary layers (first 8 bands)
+    // Expected summary layers (first 9 bands)
     let summary_layers = vec![
         "Total Shadow Hours".to_string(),
         "Average Shadow Fraction".to_string(),
         "Max Consecutive Shadow Hours".to_string(),
         "Morning Shadow Hours".to_string(),
+        "Noon Shadow Hours".to_string(),
         "Afternoon Shadow Hours".to_string(),
         "Solar Efficiency Fraction".to_string(),
         "Average Daily Solar Hours".to_string(),
@@ -664,26 +682,27 @@ async fn load_results_file(
     let shape = raster_data.data.shape();
     let (n_bands, n_rows, n_cols) = (shape[0], shape[1], shape[2]);
 
-    if n_bands < 8 {
+    if n_bands < 9 {
         return Err("Invalid results file: missing summary layers".to_string());
     }
 
-    // Extract summary stats (first 8 bands)
+    // Extract summary stats (first 9 bands)
     let summary_stats = SummaryStats {
         total_shadow_hours: raster_data.data.slice(ndarray::s![0..1, .., ..]).to_owned(),
         avg_shadow_percentage: raster_data.data.slice(ndarray::s![1..2, .., ..]).to_owned(),
         max_consecutive_shadow: raster_data.data.slice(ndarray::s![2..3, .., ..]).to_owned(),
         morning_shadow_hours: raster_data.data.slice(ndarray::s![3..4, .., ..]).to_owned(),
-        afternoon_shadow_hours: raster_data.data.slice(ndarray::s![4..5, .., ..]).to_owned(),
-        solar_efficiency_percentage: raster_data.data.slice(ndarray::s![5..6, .., ..]).to_owned(),
-        daily_solar_hours: raster_data.data.slice(ndarray::s![6..7, .., ..]).to_owned(),
-        total_available_solar_hours: raster_data.data.slice(ndarray::s![7..8, .., ..]).to_owned(),
+        noon_shadow_hours: raster_data.data.slice(ndarray::s![4..5, .., ..]).to_owned(),
+        afternoon_shadow_hours: raster_data.data.slice(ndarray::s![5..6, .., ..]).to_owned(),
+        solar_efficiency_percentage: raster_data.data.slice(ndarray::s![6..7, .., ..]).to_owned(),
+        daily_solar_hours: raster_data.data.slice(ndarray::s![7..8, .., ..]).to_owned(),
+        total_available_solar_hours: raster_data.data.slice(ndarray::s![8..9, .., ..]).to_owned(),
     };
 
-    // Extract time series data (bands 8+)
-    let num_time_bands = n_bands - 8;
+    // Extract time series data (bands 9+)
+    let num_time_bands = n_bands - 9;
     let shadow_fraction = if num_time_bands > 0 {
-        raster_data.data.slice(ndarray::s![8.., .., ..]).to_owned()
+        raster_data.data.slice(ndarray::s![9.., .., ..]).to_owned()
     } else {
         // Create empty time series if no time data
         ndarray::Array3::<f32>::zeros((0, n_rows, n_cols))

--- a/src-tauri/src/shadow_engine.rs
+++ b/src-tauri/src/shadow_engine.rs
@@ -581,9 +581,9 @@ impl ShadowEngine {
                     }
                 }
 
-                // Solar efficiency: percentage of total available solar hours that are not shadowed
+                // Solar efficiency: fraction of total available solar hours that are not shadowed (0.0-1.0)
                 let efficiency = if total_available_solar > 0.0 {
-                    ((total_available_solar - total_shadow_hours_cell) / total_available_solar * 100.0).max(0.0)
+                    ((total_available_solar - total_shadow_hours_cell) / total_available_solar).max(0.0)
                 } else {
                     0.0
                 };
@@ -603,13 +603,13 @@ impl ShadowEngine {
             solar_efficiency[[*row, *col]] = efficiency;
         }
 
-        // Calculate average shadow percentage: shadow hours / total measurement period * 100
-        // Total measurement time = number of timestamps * hour interval
+        // Calculate average shadow percentage as fraction (0.0-1.0, not 0-100)
+        // Total measurement time = number of timestamps * hour interval  
         let total_measurement_hours = timestamps.len() as f32 * self.config.hour_interval;
         println!("  Total measurement hours: {}", total_measurement_hours);
         
         let avg_shadow_percentage = if total_measurement_hours > 0.0 {
-            &total_shadow_hours / total_measurement_hours * 100.0
+            &total_shadow_hours / total_measurement_hours
         } else {
             Array2::<f32>::zeros((n_rows, n_cols))
         };

--- a/src-tauri/src/sun_position.rs
+++ b/src-tauri/src/sun_position.rs
@@ -18,35 +18,51 @@ impl SunCalculator {
         }
     }
 
-    pub fn calculate_sunrise_sunset(&self, date: &DateTime<Utc>) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+    pub fn calculate_sunrise_sunset(
+        &self,
+        date: &DateTime<Utc>,
+    ) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
         // Use civil twilight threshold (-0.833° for practical sunrise/sunset)
         let target_elevation = -0.833;
-        
+
         // Start from solar noon and search backwards/forwards for zero crossing
         let _noon = date.date_naive().and_hms_opt(12, 0, 0)?.and_utc();
-        
+
         let sunrise = self.find_solar_event(date, target_elevation, false)?;
         let sunset = self.find_solar_event(date, target_elevation, true)?;
-        
+
         Some((sunrise, sunset))
     }
 
-    fn find_solar_event(&self, date: &DateTime<Utc>, target_elevation: f64, is_sunset: bool) -> Option<DateTime<Utc>> {
+    fn find_solar_event(
+        &self,
+        date: &DateTime<Utc>,
+        target_elevation: f64,
+        is_sunset: bool,
+    ) -> Option<DateTime<Utc>> {
         let base_date = date.date_naive().and_hms_opt(12, 0, 0)?.and_utc();
-        
+
         // Search range: 6 hours before/after solar noon
-        let search_start = if is_sunset { base_date } else { base_date - chrono::Duration::hours(6) };
-        let search_end = if is_sunset { base_date + chrono::Duration::hours(6) } else { base_date };
-        
+        let search_start = if is_sunset {
+            base_date
+        } else {
+            base_date - chrono::Duration::hours(6)
+        };
+        let search_end = if is_sunset {
+            base_date + chrono::Duration::hours(6)
+        } else {
+            base_date
+        };
+
         // Binary search for elevation crossing
         let mut low = search_start;
         let mut high = search_end;
         let tolerance = chrono::Duration::minutes(1);
-        
+
         while high - low > tolerance {
             let mid = low + (high - low) / 2;
             let (_, elevation) = self.calculate_position(&mid);
-            
+
             if is_sunset {
                 if elevation > target_elevation {
                     low = mid;
@@ -61,7 +77,7 @@ impl SunCalculator {
                 }
             }
         }
-        
+
         Some(low + (high - low) / 2)
     }
 
@@ -69,15 +85,18 @@ impl SunCalculator {
         let base_date = date.date_naive().and_hms_opt(12, 0, 0).unwrap().and_utc();
         let julian_day = self.julian_day(&base_date);
         let equation_of_time = self.equation_of_time(julian_day);
-        
+
         // Solar noon occurs when hour angle = 0, so solar time = 12
         // Local time = solar time - equation of time - longitude correction
         let solar_noon_hours = 12.0 - equation_of_time / 60.0 - self.longitude / 15.0;
-        
+
         let hours = solar_noon_hours.floor() as u32;
         let minutes = ((solar_noon_hours - hours as f64) * 60.0) as u32;
-        
-        date.date_naive().and_hms_opt(hours, minutes, 0).unwrap_or(base_date.naive_utc()).and_utc()
+
+        date.date_naive()
+            .and_hms_opt(hours, minutes, 0)
+            .unwrap_or(base_date.naive_utc())
+            .and_utc()
     }
 
     pub fn get_solar_hours_for_day(&self, date: &DateTime<Utc>) -> f64 {
@@ -86,11 +105,12 @@ impl SunCalculator {
             duration.num_seconds() as f64 / 3600.0 // Convert to hours
         } else {
             // Handle polar conditions
-            let (_, elevation_noon) = self.calculate_position(&date.date_naive().and_hms_opt(12, 0, 0).unwrap().and_utc());
+            let (_, elevation_noon) = self
+                .calculate_position(&date.date_naive().and_hms_opt(12, 0, 0).unwrap().and_utc());
             if elevation_noon > 0.0 {
                 24.0 // Polar summer - sun never sets
             } else {
-                0.0  // Polar winter - sun never rises
+                0.0 // Polar winter - sun never rises
             }
         }
     }

--- a/src-tauri/src/sun_position.rs
+++ b/src-tauri/src/sun_position.rs
@@ -18,6 +18,83 @@ impl SunCalculator {
         }
     }
 
+    pub fn calculate_sunrise_sunset(&self, date: &DateTime<Utc>) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+        // Use civil twilight threshold (-0.833° for practical sunrise/sunset)
+        let target_elevation = -0.833;
+        
+        // Start from solar noon and search backwards/forwards for zero crossing
+        let _noon = date.date_naive().and_hms_opt(12, 0, 0)?.and_utc();
+        
+        let sunrise = self.find_solar_event(date, target_elevation, false)?;
+        let sunset = self.find_solar_event(date, target_elevation, true)?;
+        
+        Some((sunrise, sunset))
+    }
+
+    fn find_solar_event(&self, date: &DateTime<Utc>, target_elevation: f64, is_sunset: bool) -> Option<DateTime<Utc>> {
+        let base_date = date.date_naive().and_hms_opt(12, 0, 0)?.and_utc();
+        
+        // Search range: 6 hours before/after solar noon
+        let search_start = if is_sunset { base_date } else { base_date - chrono::Duration::hours(6) };
+        let search_end = if is_sunset { base_date + chrono::Duration::hours(6) } else { base_date };
+        
+        // Binary search for elevation crossing
+        let mut low = search_start;
+        let mut high = search_end;
+        let tolerance = chrono::Duration::minutes(1);
+        
+        while high - low > tolerance {
+            let mid = low + (high - low) / 2;
+            let (_, elevation) = self.calculate_position(&mid);
+            
+            if is_sunset {
+                if elevation > target_elevation {
+                    low = mid;
+                } else {
+                    high = mid;
+                }
+            } else {
+                if elevation < target_elevation {
+                    low = mid;
+                } else {
+                    high = mid;
+                }
+            }
+        }
+        
+        Some(low + (high - low) / 2)
+    }
+
+    pub fn calculate_solar_noon(&self, date: &DateTime<Utc>) -> DateTime<Utc> {
+        let base_date = date.date_naive().and_hms_opt(12, 0, 0).unwrap().and_utc();
+        let julian_day = self.julian_day(&base_date);
+        let equation_of_time = self.equation_of_time(julian_day);
+        
+        // Solar noon occurs when hour angle = 0, so solar time = 12
+        // Local time = solar time - equation of time - longitude correction
+        let solar_noon_hours = 12.0 - equation_of_time / 60.0 - self.longitude / 15.0;
+        
+        let hours = solar_noon_hours.floor() as u32;
+        let minutes = ((solar_noon_hours - hours as f64) * 60.0) as u32;
+        
+        date.date_naive().and_hms_opt(hours, minutes, 0).unwrap_or(base_date.naive_utc()).and_utc()
+    }
+
+    pub fn get_solar_hours_for_day(&self, date: &DateTime<Utc>) -> f64 {
+        if let Some((sunrise, sunset)) = self.calculate_sunrise_sunset(date) {
+            let duration = sunset - sunrise;
+            duration.num_seconds() as f64 / 3600.0 // Convert to hours
+        } else {
+            // Handle polar conditions
+            let (_, elevation_noon) = self.calculate_position(&date.date_naive().and_hms_opt(12, 0, 0).unwrap().and_utc());
+            if elevation_noon > 0.0 {
+                24.0 // Polar summer - sun never sets
+            } else {
+                0.0  // Polar winter - sun never rises
+            }
+        }
+    }
+
     pub fn get_position(&mut self, datetime: &DateTime<Utc>) -> (f64, f64) {
         let day = datetime.ordinal();
         let hour = datetime.hour();

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -86,6 +86,9 @@ pub struct SummaryStats {
     pub max_consecutive_shadow: Array3<f32>,
     pub morning_shadow_hours: Array3<f32>,
     pub afternoon_shadow_hours: Array3<f32>,
+    pub solar_efficiency_percentage: Array3<f32>,
+    pub daily_solar_hours: Array3<f32>,
+    pub total_available_solar_hours: Array3<f32>,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -85,6 +85,7 @@ pub struct SummaryStats {
     pub avg_shadow_percentage: Array3<f32>,
     pub max_consecutive_shadow: Array3<f32>,
     pub morning_shadow_hours: Array3<f32>,
+    pub noon_shadow_hours: Array3<f32>,
     pub afternoon_shadow_hours: Array3<f32>,
     pub solar_efficiency_percentage: Array3<f32>,
     pub daily_solar_hours: Array3<f32>,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ interface AllSummaryData {
   avg_shadow_percentage: number[][];
   max_consecutive_shadow: number[][];
   morning_shadow_hours: number[][];
+  noon_shadow_hours: number[][];
   afternoon_shadow_hours: number[][];
   bounds: RasterBounds;
   transform: number[];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,8 @@ interface AllSummaryData {
   morning_shadow_hours: number[][];
   noon_shadow_hours: number[][];
   afternoon_shadow_hours: number[][];
+  daily_solar_hours: number[][];
+  total_available_solar_hours: number[][];
   bounds: RasterBounds;
   transform: number[];
 }

--- a/src/components/LeafletMapView.tsx
+++ b/src/components/LeafletMapView.tsx
@@ -30,6 +30,7 @@ interface AllSummaryData {
   avg_shadow_percentage: number[][];
   max_consecutive_shadow: number[][];
   morning_shadow_hours: number[][];
+  noon_shadow_hours: number[][];
   afternoon_shadow_hours: number[][];
   bounds: RasterBounds;
   transform: number[];
@@ -402,15 +403,22 @@ const LeafletMapView: React.FC<MapViewProps> = ({
         const totalHours = getRasterValueAtLatLng(e.latlng, allSummaryData.total_shadow_hours);
         const maxConsecutive = getRasterValueAtLatLng(e.latlng, allSummaryData.max_consecutive_shadow);
         const morningHours = getRasterValueAtLatLng(e.latlng, allSummaryData.morning_shadow_hours);
+        const noonHours = getRasterValueAtLatLng(e.latlng, allSummaryData.noon_shadow_hours);
         const afternoonHours = getRasterValueAtLatLng(e.latlng, allSummaryData.afternoon_shadow_hours);
 
         if (shadowValue !== null) {
+          // Calculate percentages based on approximate time periods
+          // Assuming morning: 6h, noon: 4h, afternoon: 6h for a typical day
+          const morningPercent = morningHours ? (morningHours * 100 / 6) : null;
+          const noonPercent = noonHours ? (noonHours * 100 / 4) : null;
+          const afternoonPercent = afternoonHours ? (afternoonHours * 100 / 6) : null;
+
           const popupContent = `
-            <div style="font-family: sans-serif; min-width: 200px;">
+            <div style="font-family: sans-serif; min-width: 240px;">
               <h4 style="margin: 0 0 12px 0; color: #333; font-size: 16px; border-bottom: 2px solid #4f46e5; padding-bottom: 4px;">
                 📊 Shadow Statistics
               </h4>
-              <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 8px; font-size: 13px;">
+              <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 8px; font-size: 13px; margin-bottom: 12px;">
                 <div style="background: #f3f4f6; padding: 8px; border-radius: 4px;">
                   <div style="font-weight: bold; color: #6b7280; font-size: 11px;">AVERAGE SHADOW</div>
                   <div style="font-size: 16px; color: #1f2937; font-weight: bold;">${Math.round(shadowValue * 100)}%</div>
@@ -423,10 +431,28 @@ const LeafletMapView: React.FC<MapViewProps> = ({
                   <div style="font-weight: bold; color: #991b1b; font-size: 11px;">MAX CONSECUTIVE</div>
                   <div style="font-size: 16px; color: #991b1b; font-weight: bold;">${maxConsecutive?.toFixed(1) || 'N/A'}h</div>
                 </div>
-                <div style="background: #ecfdf5; padding: 8px; border-radius: 4px;">
-                  <div style="font-weight: bold; color: #065f46; font-size: 11px;">MORNING/AFTERNOON</div>
-                  <div style="font-size: 14px; color: #065f46; font-weight: bold;">${morningHours?.toFixed(1) || 'N/A'}h / ${afternoonHours?.toFixed(1) || 'N/A'}h</div>
+                <div style="background: #ddd6fe; padding: 8px; border-radius: 4px;">
+                  <div style="font-weight: bold; color: #5b21b6; font-size: 11px;">SOLAR EFFICIENCY</div>
+                  <div style="font-size: 16px; color: #5b21b6; font-weight: bold;">${Math.round((1 - shadowValue) * 100)}%</div>
                 </div>
+              </div>
+              <div style="background: #f9fafb; padding: 12px; border-radius: 8px; border: 1px solid #e5e7eb;">
+                <h5 style="margin: 0 0 8px 0; color: #374151; font-size: 14px; font-weight: bold;">🕒 Time Period Analysis</h5>
+                <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; font-size: 12px;">
+                  <div style="text-align: center; padding: 6px; background: #fef3c7; border-radius: 4px;">
+                    <div style="font-weight: bold; color: #92400e; font-size: 10px;">MORNING</div>
+                    <div style="color: #92400e; font-weight: bold;">${morningPercent?.toFixed(0) || 'N/A'}%</div>
+                  </div>
+                  <div style="text-align: center; padding: 6px; background: #fef5e7; border-radius: 4px;">
+                    <div style="font-weight: bold; color: #c2410c; font-size: 10px;">NOON</div>
+                    <div style="color: #c2410c; font-weight: bold;">${noonPercent?.toFixed(0) || 'N/A'}%</div>
+                  </div>
+                  <div style="text-align: center; padding: 6px; background: #ecfdf5; border-radius: 4px;">
+                    <div style="font-weight: bold; color: #065f46; font-size: 10px;">AFTERNOON</div>
+                    <div style="color: #065f46; font-weight: bold;">${afternoonPercent?.toFixed(0) || 'N/A'}%</div>
+                  </div>
+                </div>
+              </div>
               </div>
               <div style="margin-top: 8px; font-size: 11px; color: #6b7280; text-align: center;">
                 📍 Lat: ${e.latlng.lat.toFixed(5)}, Lng: ${e.latlng.lng.toFixed(5)}

--- a/src/components/LeafletMapView.tsx
+++ b/src/components/LeafletMapView.tsx
@@ -441,14 +441,17 @@ const LeafletMapView: React.FC<MapViewProps> = ({
                   <div style="text-align: center; padding: 6px; background: #fef3c7; border-radius: 4px;">
                     <div style="font-weight: bold; color: #92400e; font-size: 10px;">MORNING</div>
                     <div style="color: #92400e; font-weight: bold;">${morningPercent.toFixed(1)}%</div>
+                    <div style="color: #92400e; font-size: 10px;">${morningHours?.toFixed(1) || '0.0'}h</div>
                   </div>
                   <div style="text-align: center; padding: 6px; background: #fef5e7; border-radius: 4px;">
                     <div style="font-weight: bold; color: #c2410c; font-size: 10px;">NOON</div>
                     <div style="color: #c2410c; font-weight: bold;">${noonPercent.toFixed(1)}%</div>
+                    <div style="color: #c2410c; font-size: 10px;">${noonHours?.toFixed(1) || '0.0'}h</div>
                   </div>
                   <div style="text-align: center; padding: 6px; background: #ecfdf5; border-radius: 4px;">
                     <div style="font-weight: bold; color: #065f46; font-size: 10px;">AFTERNOON</div>
                     <div style="color: #065f46; font-weight: bold;">${afternoonPercent.toFixed(1)}%</div>
+                    <div style="color: #065f46; font-size: 10px;">${afternoonHours?.toFixed(1) || '0.0'}h</div>
                   </div>
                 </div>
                 <div style="margin-top: 6px; font-size: 10px; color: #6b7280; text-align: center;">

--- a/src/components/LeafletMapView.tsx
+++ b/src/components/LeafletMapView.tsx
@@ -407,11 +407,10 @@ const LeafletMapView: React.FC<MapViewProps> = ({
         const afternoonHours = getRasterValueAtLatLng(e.latlng, allSummaryData.afternoon_shadow_hours);
 
         if (shadowValue !== null) {
-          // Calculate percentages based on approximate time periods
-          // Assuming morning: 6h, noon: 4h, afternoon: 6h for a typical day
-          const morningPercent = morningHours ? (morningHours * 100 / 6) : null;
-          const noonPercent = noonHours ? (noonHours * 100 / 4) : null;
-          const afternoonPercent = afternoonHours ? (afternoonHours * 100 / 6) : null;
+          // Calculate percentages as portion of total shadow hours
+          const morningPercent = (totalHours && totalHours > 0 && morningHours) ? (morningHours / totalHours * 100) : 0;
+          const noonPercent = (totalHours && totalHours > 0 && noonHours) ? (noonHours / totalHours * 100) : 0;
+          const afternoonPercent = (totalHours && totalHours > 0 && afternoonHours) ? (afternoonHours / totalHours * 100) : 0;
 
           const popupContent = `
             <div style="font-family: sans-serif; min-width: 240px;">
@@ -437,20 +436,23 @@ const LeafletMapView: React.FC<MapViewProps> = ({
                 </div>
               </div>
               <div style="background: #f9fafb; padding: 12px; border-radius: 8px; border: 1px solid #e5e7eb;">
-                <h5 style="margin: 0 0 8px 0; color: #374151; font-size: 14px; font-weight: bold;">🕒 Time Period Analysis</h5>
+                <h5 style="margin: 0 0 8px 0; color: #374151; font-size: 14px; font-weight: bold;">🕒 Shadow Distribution by Time Period</h5>
                 <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; font-size: 12px;">
                   <div style="text-align: center; padding: 6px; background: #fef3c7; border-radius: 4px;">
                     <div style="font-weight: bold; color: #92400e; font-size: 10px;">MORNING</div>
-                    <div style="color: #92400e; font-weight: bold;">${morningPercent?.toFixed(0) || 'N/A'}%</div>
+                    <div style="color: #92400e; font-weight: bold;">${morningPercent.toFixed(1)}%</div>
                   </div>
                   <div style="text-align: center; padding: 6px; background: #fef5e7; border-radius: 4px;">
                     <div style="font-weight: bold; color: #c2410c; font-size: 10px;">NOON</div>
-                    <div style="color: #c2410c; font-weight: bold;">${noonPercent?.toFixed(0) || 'N/A'}%</div>
+                    <div style="color: #c2410c; font-weight: bold;">${noonPercent.toFixed(1)}%</div>
                   </div>
                   <div style="text-align: center; padding: 6px; background: #ecfdf5; border-radius: 4px;">
                     <div style="font-weight: bold; color: #065f46; font-size: 10px;">AFTERNOON</div>
-                    <div style="color: #065f46; font-weight: bold;">${afternoonPercent?.toFixed(0) || 'N/A'}%</div>
+                    <div style="color: #065f46; font-weight: bold;">${afternoonPercent.toFixed(1)}%</div>
                   </div>
+                </div>
+                <div style="margin-top: 6px; font-size: 10px; color: #6b7280; text-align: center;">
+                  Shows what portion of total shadow occurs in each time period
                 </div>
               </div>
               </div>

--- a/src/components/LeafletMapView.tsx
+++ b/src/components/LeafletMapView.tsx
@@ -290,33 +290,33 @@ const LeafletMapView: React.FC<MapViewProps> = ({
         let r, g, b, a;
         
         if (shadowValue <= 0.5) {
-          // Low shadow areas (0-50%): Sand/white tones with high transparency
+          // Low shadow areas (0-50%): Sand/white tones with moderate transparency
           const t = shadowValue / 0.5;
           r = Math.round(255 - t * 35);   // 255 -> 220 (stay light/sandy)
           g = Math.round(250 - t * 30);   // 250 -> 220 (warm sand color)
           b = Math.round(235 - t * 65);   // 235 -> 170 (slight brown tint)
-          a = Math.round(20 + t * 60);    // Very transparent: 20 -> 80
+          a = Math.round(60 + t * 80);    // More visible: 60 -> 140 (24%-55% opacity)
         } else if (shadowValue < 0.7) {
           // Medium shadow: Transition from sand to orange
           const t = (shadowValue - 0.5) / 0.2;
           r = Math.round(220 + t * 35);   // 220 -> 255
           g = Math.round(220 - t * 70);   // 220 -> 150
           b = Math.round(170 - t * 170);  // 170 -> 0
-          a = Math.round(80 + t * 80);    // 80 -> 160
+          a = Math.round(140 + t * 60);   // 140 -> 200 (55%-78% opacity)
         } else if (shadowValue < 0.85) {
           // Heavy shadow: Orange to red
           const t = (shadowValue - 0.7) / 0.15;
           r = 255;                        // Stay full red
           g = Math.round(150 - t * 90);   // 150 -> 60
           b = Math.round(t * 30);         // 0 -> 30
-          a = Math.round(160 + t * 60);   // 160 -> 220
+          a = Math.round(200 + t * 35);   // 200 -> 235 (78%-92% opacity)
         } else {
           // Very heavy shadow: Red to dark purple
           const t = (shadowValue - 0.85) / 0.15;
           r = Math.round(255 - t * 155);  // 255 -> 100
           g = Math.round(60 - t * 40);    // 60 -> 20
           b = Math.round(30 + t * 120);   // 30 -> 150
-          a = Math.round(220 + t * 35);   // 220 -> 255 (fully opaque for highest shadows)
+          a = Math.round(235 + t * 20);   // 235 -> 255 (92%-100% opacity)
         }
         
         imageData.data[idx] = r;


### PR DESCRIPTION
## Summary
- Fixed contradictory shadow metrics in popup display
- Improved UI clarity by showing complementary shadow/sun hours instead of conflicting percentage vs absolute values  
- Added missing data fields to prevent popup failures
- Enhanced user experience with collapsible instructions

## Changes
- Redesigned popup to show SHADOW HOURS/DAY and SUN HOURS/DAY (complementary metrics)
- Fixed backend data extraction for daily_solar_hours and total_available_solar_hours
- Added calculation cap to prevent shadow hours exceeding solar day length
- Made instructions collapsible and mode-specific (Calculate Shadows only)
- Renamed "View Results" to "Load Results" for better UX